### PR TITLE
0.3.0 Release

### DIFF
--- a/.github/workflows/linux_dynamic.yml
+++ b/.github/workflows/linux_dynamic.yml
@@ -26,5 +26,5 @@ jobs:
           args: --release
       - uses: actions/upload-artifact@v2
         with:
-          name: binary
+          name: linux_dynamic
           path: target/release/starsector_mod_manager

--- a/.github/workflows/linux_dynamic.yml
+++ b/.github/workflows/linux_dynamic.yml
@@ -1,4 +1,4 @@
-name: Build-Linux-Static
+name: Build-Linux-Dynamic
 
 on:
   push:

--- a/.github/workflows/linux_static.yml
+++ b/.github/workflows/linux_static.yml
@@ -1,0 +1,35 @@
+name: Build-Linux-Static
+
+on:
+  push:
+    branches:
+      - release
+  pull_request:
+    branches:
+      - release
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Rust project
+    runs-on: ubuntu-latest
+    env:
+      PKG_CONFIG_ALLOW_CROSS: 1
+    steps:
+      - name: Install Dependencies
+        run: sudo apt-get update; sudo apt-get install libarchive-dev musl-tools
+      - name: Link g++ to musl-g++
+        run: sudo ln -s /bin/g++ /bin/musl-g++
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: x86_64-unknown-linux-musl
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --target=x86_64-unknown-linux-musl
+      - uses: actions/upload-artifact@v2
+        with:
+          name: binary
+          path: target/x86_64-unknown-linux-musl/release/starsector_mod_manager

--- a/.github/workflows/linux_static.yml
+++ b/.github/workflows/linux_static.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - release
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/linux_static.yml
+++ b/.github/workflows/linux_static.yml
@@ -1,0 +1,29 @@
+name: Build-Linux-Static
+
+on:
+  push:
+    branches:
+      - release
+  pull_request:
+    branches:
+      - release
+
+jobs:
+  build:
+    name: Rust project
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Dependencies
+        run: sudo apt-get update; sudo apt-get install libarchive-dev
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release
+      - uses: actions/upload-artifact@v2
+        with:
+          name: binary
+          path: target/release/starsector_mod_manager

--- a/.github/workflows/linux_static.yml
+++ b/.github/workflows/linux_static.yml
@@ -31,5 +31,5 @@ jobs:
           args: --release --target=x86_64-unknown-linux-musl
       - uses: actions/upload-artifact@v2
         with:
-          name: binary
+          name: linux_static
           path: target/x86_64-unknown-linux-musl/release/starsector_mod_manager

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - release
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,27 @@
+name: Build-macOS
+
+on:
+  push:
+    branches:
+      - release
+  pull_request:
+    branches:
+      - release
+
+jobs:
+  build:
+    name: Rust project
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release
+      - uses: actions/upload-artifact@v2
+        with:
+          name: binary
+          path: target/release/starsector_mod_manager

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -24,5 +24,5 @@ jobs:
           args: --release
       - uses: actions/upload-artifact@v2
         with:
-          name: binary
+          name: macos
           path: target/release/starsector_mod_manager

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,28 @@
+name: Build-Windows-Static
+
+on:
+  push:
+    branches:
+      - release
+  pull_request:
+    branches:
+      - release
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Rust project
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release
+      - uses: actions/upload-artifact@v2
+        with:
+          name: binary
+          path: target/release/starsector_mod_manager.exe

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,5 +24,5 @@ jobs:
           args: --release
       - uses: actions/upload-artifact@v2
         with:
-          name: binary
+          name: windows
           path: target/release/starsector_mod_manager.exe

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2785,6 +2785,7 @@ dependencies = [
  "pin-project-lite",
  "rustls",
  "serde",
+ "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,5 @@ zip = "0.5.9"
 unrar = "0.4.4"
 opener = "0.5"
 
-[target.'cfg(unix)'.dependencies]
+[target.'cfg(target_os = "linux")'.dependencies]
 compress-tools = "0.11.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ serde_json = "1.0"
 json5 = "0.3.0"
 json_comments = "0.1.0"
 if_chain = "1.0.1"
-reqwest = { version = "0.11.3", default-features = false, features = ["rustls-tls"]}
+reqwest = { version = "0.11.3", default-features = false, features = ["rustls-tls", "json"]}
 serde-aux = "2.1.1"
 handwritten-json = { git = "https://github.com/atlanticaccent/rust-handwritten-json.git" }
 zip = "0.5.9"

--- a/src/archive_handler.rs
+++ b/src/archive_handler.rs
@@ -116,11 +116,11 @@ pub fn handle_archive(file: &String, dest: &String, file_name: &String) -> Resul
       }
     },
     "application/x-7z-compressed" => {
-      #[cfg(target_family = "unix")]
+      #[cfg(target_os = "linux")]
       return compress_tools(file, dest);
 
-      // null-op on windows
-      #[cfg(not(target_family = "unix"))]
+      // null-op on anything other than linux
+      #[cfg(not(target_os = "linux"))]
       Ok(false)
     },
     _ => {
@@ -130,7 +130,7 @@ pub fn handle_archive(file: &String, dest: &String, file_name: &String) -> Resul
   }
 }
 
-#[cfg(target_family = "unix")]
+#[cfg(target_os = "linux")]
 fn compress_tools(file: &String, dest: &String) -> Result<bool, Box<dyn Error + Send>> {
   match fs::File::open(&file) {
     Ok(mut source) => {
@@ -146,7 +146,7 @@ fn compress_tools(file: &String, dest: &String) -> Result<bool, Box<dyn Error + 
 }
 
 // null-op on windows
-#[cfg(not(target_family = "unix"))]
+#[cfg(not(target_os = "linux"))]
 fn _7z_support(_: &String, _: &String) -> Result<bool, Box<dyn Error + Send>> {
   Ok(false)
 }

--- a/src/archive_handler.rs
+++ b/src/archive_handler.rs
@@ -76,17 +76,17 @@ pub fn handle_archive(file: &String, dest: &String, file_name: &String) -> Resul
                   };
                   
                   if (&*file.name()).ends_with('/') {
-                    dbg!("File {} extracted to \"{}\"", i, outpath.display());
+                    // dbg!("File {} extracted to \"{}\"", i, outpath.display());
                     if let Err(err) = fs::create_dir_all(&outpath) {
                       return Err(Box::new(err));
                     }
                   } else {
-                    dbg!(
-                      "File {} extracted to \"{}\" ({} bytes)",
-                      i,
-                      outpath.display(),
-                      file.size()
-                    );
+                    // dbg!(
+                    //   "File {} extracted to \"{}\" ({} bytes)",
+                    //   i,
+                    //   outpath.display(),
+                    //   file.size()
+                    // );
                     if let Some(p) = outpath.parent() {
                       if !p.exists() {
                         if let Err(err) = fs::create_dir_all(&p) {
@@ -124,7 +124,7 @@ pub fn handle_archive(file: &String, dest: &String, file_name: &String) -> Resul
       Ok(false)
     },
     _ => {
-      dbg!("is something else");
+      // dbg!("is something else");
       return Ok(false);
     },
   }

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -4,7 +4,7 @@ use serde::{Serialize, Deserialize};
 use serde_json;
 
 const DEV_VERSION: &'static str = "IN_DEV";
-const TAG: &'static str = DEV_VERSION;
+const TAG: &'static str = "v0.3.0";
 
 // https://users.rust-lang.org/t/show-value-only-in-debug-mode/43686/5
 macro_rules! dbg {

--- a/src/gui/mod_list.rs
+++ b/src/gui/mod_list.rs
@@ -256,7 +256,15 @@ impl ModList {
 
                     Command::batch(self.parse_mod_folder())
                   },
-                  _ => Command::none()
+                  _ => {
+                    if let Some(parent_temp_path) = maybe_parent_path {
+                      if remove_dir_all(parent_temp_path).is_err() {
+                        println!("Failed to remove temporary directory.")
+                      }
+                    }
+
+                    Command::none()
+                  }
                 }
               },
               other => {

--- a/src/gui/mod_list.rs
+++ b/src/gui/mod_list.rs
@@ -510,13 +510,40 @@ impl ModList {
                 (ModEntryComp::Author, false) => left.author.cmp(&right.author),
                 (ModEntryComp::Enabled, false) => left.enabled.cmp(&right.enabled),
                 (ModEntryComp::GameVersion, false) => left.game_version.cmp(&right.game_version),
-                (ModEntryComp::Version, false) => left.version_checker.cmp(&right.version_checker),
+                (ModEntryComp::Version, false) => {
+                  if left.update_status.is_none() && right.update_status.is_none() {
+                    std::cmp::Ordering::Equal
+                  } else if left.update_status.is_none() {
+                    std::cmp::Ordering::Greater
+                  } else if right.update_status.is_none() {
+                    std::cmp::Ordering::Less
+                  } else {
+                    if left.update_status.cmp(&right.update_status) == std::cmp::Ordering::Equal {
+                      left.version_checker.cmp(&right.version_checker)
+                    } else {
+                      left.update_status.cmp(&right.update_status)
+                    }
+                  }
+
+                },
                 (ModEntryComp::ID, true) => right.id.cmp(&left.id),
                 (ModEntryComp::Name, true) => right.name.cmp(&left.name),
                 (ModEntryComp::Author, true) => right.author.cmp(&left.author),
                 (ModEntryComp::Enabled, true) => right.enabled.cmp(&left.enabled),
                 (ModEntryComp::GameVersion, true) => right.game_version.cmp(&left.game_version),
-                (ModEntryComp::Version, true) => right.version_checker.cmp(&left.version_checker),
+                (ModEntryComp::Version, true) => {
+                  if right.update_status.is_none() && left.update_status.is_none() {
+                    std::cmp::Ordering::Equal
+                  } else if right.update_status.is_none() {
+                    std::cmp::Ordering::Greater
+                  } else if left.update_status.is_none() {
+                    std::cmp::Ordering::Less
+                  } else if right.update_status.cmp(&left.update_status) == std::cmp::Ordering::Equal {
+                    right.version_checker.cmp(&left.version_checker)
+                  } else {
+                    right.update_status.cmp(&left.update_status)
+                  }
+                },
               }
             });
 
@@ -799,13 +826,13 @@ impl std::fmt::Display for ToolOptions {
   }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum UpdateStatus {
+  Error,
   Major(ModVersion),
   Minor(ModVersion),
   Patch(ModVersion),
   UpToDate,
-  Error
 }
 
 impl Display for UpdateStatus {

--- a/src/gui/mod_list.rs
+++ b/src/gui/mod_list.rs
@@ -308,7 +308,7 @@ impl ModList {
                         entry.update_status = Some(UpdateStatus::Minor(version))
                       } else {
                         // debug_println!("New patch available.");
-                        entry.update_status = Some(UpdateStatus::Patch(version.patch))
+                        entry.update_status = Some(UpdateStatus::Patch(version))
                       };
                       // debug_println!("{:?}", entry.version_checker.as_ref().unwrap().version);
                       entry.remote_version = Some(remote_version_meta);
@@ -803,7 +803,7 @@ impl std::fmt::Display for ToolOptions {
 pub enum UpdateStatus {
   Major(ModVersion),
   Minor(ModVersion),
-  Patch(String),
+  Patch(ModVersion),
   UpToDate,
   Error
 }
@@ -982,16 +982,15 @@ impl ModEntry {
                     .width(Length::Fill)
                     .height(Length::Fill),
                     match status {
-                      UpdateStatus::Major(delta) | UpdateStatus::Minor(delta) => {
+                      UpdateStatus::Major(delta) | UpdateStatus::Minor(delta) | UpdateStatus::Patch(delta) => {
                         let local = &self.version_checker.as_ref().unwrap().version;
                         let remote = ModVersion {
                           major: local.major + delta.major,
                           minor: local.minor + delta.minor,
                           patch: delta.patch.clone()
                         };
-                        format!("{:?} update available.\nLocal: {} - Update: {}", status, local, remote)
+                        format!("{} update available.\nUpdate: {}", status, remote)
                       },
-                      UpdateStatus::Patch(delta) => format!("Patch available.\nLocal: {} - Update: {}", &self.version_checker.as_ref().unwrap().version.patch, delta),
                       UpdateStatus::UpToDate => format!("Up to date!"),
                       UpdateStatus::Error => format!("Could not retrieve remote update data.")
                     },

--- a/src/gui/mod_list.rs
+++ b/src/gui/mod_list.rs
@@ -91,9 +91,13 @@ impl ModList {
   pub fn update(&mut self, message: ModListMessage) -> Command<ModListMessage> {
     match message {
       ModListMessage::SetRoot(root_dir) => {
-        self.root_dir = root_dir;
-
-        Command::batch(self.parse_mod_folder())
+        if self.root_dir != root_dir {
+          self.root_dir = root_dir;
+  
+          Command::batch(self.parse_mod_folder())
+        } else {
+          Command::none()
+        }
       },
       ModListMessage::ModEntryMessage(id, message) => {
         if let Some(entry) = self.mods.get_mut(&id) {

--- a/src/gui/mod_list.rs
+++ b/src/gui/mod_list.rs
@@ -816,7 +816,7 @@ impl std::fmt::Display for ToolOptions {
       "{}",
       match self {
         ToolOptions::Default => "Tools",
-        ToolOptions::EnableAll => "Enabled All",
+        ToolOptions::EnableAll => "Enable All",
         ToolOptions::DisableAll => "Disable All",
         ToolOptions::FilterEnabled => "Show Enabled",
         ToolOptions::FilterDisabled => "Show Disabled",

--- a/src/gui/mod_list/headings.rs
+++ b/src/gui/mod_list/headings.rs
@@ -1,0 +1,112 @@
+use iced::{PaneGrid, pane_grid, Button, button, Text, Row, Space, Element, Command, Length};
+use if_chain::if_chain;
+
+use crate::style;
+use super::ModEntryComp;
+
+#[derive(Debug, Clone)]
+pub enum HeadingsMessage {
+  HeadingPressed(ModEntryComp),
+  Resized(pane_grid::ResizeEvent)
+}
+
+pub struct Headings {
+  headings: pane_grid::State<Content>,
+  pub enabled_name_split: pane_grid::Split,
+  pub name_id_split: pane_grid::Split,
+  pub id_author_split: pane_grid::Split,
+  pub author_mod_version_split: pane_grid::Split,
+  pub mod_version_ss_version_split: pane_grid::Split,
+}
+
+impl Headings {
+  pub fn new() -> Result<Self, ()> {
+    let (mut state, enabled_pane) = pane_grid::State::new(Content::new(format!("Enabled"), ModEntryComp::Enabled));
+
+    if_chain! {
+      if let Some((name_pane, enabled_name_split)) = state.split(pane_grid::Axis::Vertical, &enabled_pane, Content::new(format!("Name"), ModEntryComp::Name));
+      if let Some((id_pane, name_id_split)) = state.split(pane_grid::Axis::Vertical, &name_pane, Content::new(format!("ID"), ModEntryComp::ID));
+      if let Some((author_pane, id_author_split)) = state.split(pane_grid::Axis::Vertical, &id_pane, Content::new(format!("Author"), ModEntryComp::Author));
+      if let Some((mod_version_pane, author_mod_version_split)) = state.split(pane_grid::Axis::Vertical, &author_pane, Content::new(format!("Mod Version"), ModEntryComp::Version));
+      if let Some((_, mod_version_ss_version_split)) = state.split(pane_grid::Axis::Vertical, &mod_version_pane, Content::new(format!("Starsector Version"), ModEntryComp::GameVersion));
+      then {
+        state.resize(&enabled_name_split, 3.0 / 43.0);
+        state.resize(&name_id_split, 1.0 / 5.0);
+        state.resize(&id_author_split, 1.0 / 4.0);
+        state.resize(&author_mod_version_split, 1.0 / 3.0);
+        state.resize(&mod_version_ss_version_split, 1.0 / 2.0);
+
+        Ok(Headings {
+          headings: state,
+          enabled_name_split,
+          name_id_split,
+          id_author_split,
+          author_mod_version_split,
+          mod_version_ss_version_split,
+        })
+      } else {
+        Err(())
+      }
+    }
+  }
+
+  pub fn update(&mut self, message: HeadingsMessage) -> Command<HeadingsMessage> {
+    match message {
+      HeadingsMessage::HeadingPressed(_) => Command::none(),
+      HeadingsMessage::Resized(pane_grid::ResizeEvent { split, ratio }) => {
+        if split != self.enabled_name_split {
+          self.headings.resize(&split, ratio);
+        }
+
+        Command::none()
+      }
+    }
+  }
+
+  pub fn view(&mut self) -> Element<HeadingsMessage> {
+    PaneGrid::new(
+      &mut self.headings,
+      |_, content| {
+        pane_grid::Content::new(content.view())
+      }
+    )
+    .on_resize(10, HeadingsMessage::Resized)
+    .height(iced::Length::Units(30))
+    .into()
+  }
+}
+
+pub struct Content {
+  text: String,
+  button_state: button::State,
+  cmp: ModEntryComp
+}
+
+impl Content {
+  fn new(text: String, cmp: ModEntryComp) -> Self {
+    Content {
+      text,
+      button_state: button::State::new(),
+      cmp
+    }
+  }
+
+  fn view(&mut self) -> Element<HeadingsMessage> {
+    Row::new()
+      .push(Space::with_width(Length::Units(5)))
+      .push(
+        Button::new(
+          &mut self.button_state,
+          Text::new(self.text.clone())
+        )
+        .style(style::button_none::Button)
+        .on_press(HeadingsMessage::HeadingPressed(self.cmp.clone()))
+        .width(Length::Fill)
+        .height(Length::Fill)
+      )
+      .push(Space::with_width(Length::Units(5)))
+      .width(Length::Fill)
+      .height(Length::Fill)
+      .into()
+  }
+}

--- a/src/gui/settings.rs
+++ b/src/gui/settings.rs
@@ -91,10 +91,10 @@ impl Settings {
 
         if let Ok(some_path) = diag.show_open_single_dir() {
           if let Some(ref path_buf) = some_path {
-            self.new_dir = Some(path_buf.to_string_lossy().into_owned())
+            self.new_dir = Some(path_buf.to_string_lossy().into_owned());
+
+            self.root_dir = some_path;
           }
-          
-          self.root_dir = some_path;
         }
 
         return Command::none();

--- a/src/style.rs
+++ b/src/style.rs
@@ -47,6 +47,32 @@ pub mod button_only_hover {
   }
 }
 
+pub mod button_highlight_and_hover {
+  use iced::{button, Color, Vector};
+
+  pub struct Button;
+
+  impl button::StyleSheet for Button {
+    fn active(&self) -> button::Style {
+      button::Style {
+        shadow_offset: Vector::new(0.0, 0.0),
+        text_color: Color::WHITE.into(),
+        border_color: Color::from_rgb8(0x24, 0xA0, 0xED),
+        border_width: 1.0,
+        ..button::Style::default()
+      }
+    }
+  
+    fn hovered(&self) -> button::Style {
+      button::Style {
+        background: Color::from_rgb8(0x41, 0x41, 0x41).into(),
+        text_color: Color::WHITE.into(),
+        ..button::Style::default()
+      }
+    }
+  }
+}
+
 pub mod nav_bar {
   use iced::{container, Color};
 


### PR DESCRIPTION
**New**:
- Program update checker
- Add `Tools` menu
  - Allows filtering by a number of features, such as enabled, disabled, update available, etc
  - Allows manual refreshing of the mod list, for cases where a user might run a manual install and want it to appear in the manager
- Collect batch install messages so that they don't lock up the program
- Resizable mod list columns
- The `Apply` button in settings is now highlighted after a change is made
- Improve sorting when sorting by update status
  - Order is now: Error -> Major Update -> Minor Update -> Patch Update -> Up to date -> Version Checker Unsupported
- Provisional macOS support

**Fixed**:
- Remove temporary files when user declines install due to folder/ID conflict
- No longer clear install directory when pressing cancel on folder picker
- Clean up mod update tooltip