### PR TITLE
Support symbolically linked mod folders

### DIFF
--- a/src/gui/mod_list.rs
+++ b/src/gui/mod_list.rs
@@ -629,7 +629,7 @@ impl ModList {
           .filter_map(|entry| entry.ok())
           .filter(|entry| {
             if let Ok(file_type) = entry.file_type() {
-              file_type.is_dir()
+              file_type.is_dir() || file_type.is_symlink()
             } else {
               false
             }


### PR DESCRIPTION
Fixes #72

Add clause to allow symlinks when traversing the mods directory.