### PR TITLE
Update version numbers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3136,7 +3136,7 @@ dependencies = [
 
 [[package]]
 name = "starsector_mod_manager"
-version = "0.3.0"
+version = "0.4.1"
 dependencies = [
  "compress-tools",
  "directories",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starsector_mod_manager"
-version = "0.3.0"
+version = "0.4.1"
 authors = ["ikl"]
 edition = "2018"
 description = "A mod manager for the game Starsector"

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -4,7 +4,7 @@ use serde::{Serialize, Deserialize};
 use serde_json;
 
 const DEV_VERSION: &'static str = "IN_DEV";
-const TAG: &'static str = "v0.3.0";
+const TAG: &'static str = env!("CARGO_PKG_VERSION");
 
 // https://users.rust-lang.org/t/show-value-only-in-debug-mode/43686/5
 macro_rules! dbg {
@@ -240,7 +240,7 @@ impl Application for App {
           .padding(5)
         )
       },
-      Some(Ok(remote)) if remote < &String::from(TAG) => Container::new(Text::new("Are you from the future?")).padding(5),
+      Some(Ok(remote)) if remote < &format!("v{}", TAG) => Container::new(Text::new("Are you from the future?")).padding(5),
       Some(Ok(_)) | None => Container::new(Text::new(TAG)).padding(5),
       Some(Err(_)) => Container::new(Text::new(&err_string)).padding(5),
     }.width(Length::Fill).align_x(iced::Align::Center);


### PR DESCRIPTION
Technically the last PR was v0.4, so this also bumps it to to v0.4.1 whilst also setting the minor version to the correct value.