### PR TITLE
Potentially fix macOS build fail

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,6 +23,8 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      - name: Install cargo-bundle
+        run: cargo install cargo-bundle
       - name: Check cache
         uses: actions/cache@v2
         with:
@@ -33,8 +35,6 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Install cargo-bundle
-        run: cargo install cargo-bundle
       - name: Run cargo-bundle
         run: cargo bundle --release
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
Move cargo-bundle install to before restoring the cargo cache.

Functionally, this is no different from running the install with the --force flag.