### PR TITLE
Fix for macOS not able to select Starsector app

### DIFF
--- a/src/gui/settings.rs
+++ b/src/gui/settings.rs
@@ -87,7 +87,7 @@ impl Settings {
       },
       SettingsMessage::OpenNativeFilePick => {
         let maybe_path = if cfg!(target_os = "macos") {
-          tfd::save_file_dialog("Select Starsector app:", UserDirs::new().unwrap().document_dir().unwrap().to_str().unwrap())
+          tfd::open_file_dialog("Select Starsector app:", UserDirs::new().unwrap().document_dir().unwrap().to_str().unwrap(), Some((vec!["*.app"], "*.app")), false)
         } else {
           tfd::select_folder_dialog("Select Starsector installation:", UserDirs::new().unwrap().document_dir().unwrap().to_str().unwrap())
         };


### PR DESCRIPTION
Incorrectly using the save_file_dialog instead of the select_file_dialog. Hopefully the filter used here isn't overly restrictive.