### PR TITLE
Version 0.4.3

### DIFF
--- a/.github/workflows/check_deploy_version.yml
+++ b/.github/workflows/check_deploy_version.yml
@@ -1,0 +1,25 @@
+name: Check Bump on Version
+
+on:
+  pull_request:
+    branches:
+      - release
+
+jobs:
+  check_version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - run: git fetch --all --tags
+
+      - name: Check Release Version
+        uses: thebongy/version-check@v1
+        with:
+          file: Cargo.toml
+          tagFormat: v${version}
+          failBuild: true
+        id: version_check
+      - name:
+        run: |
+          echo "Version ${{steps.version_check.outputs.releaseVersion}}"

--- a/.github/workflows/windows_debug.yml
+++ b/.github/workflows/windows_debug.yml
@@ -1,0 +1,37 @@
+name: Build-Windows-Static-Debug
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Rust project
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Install libarchive
+        uses: lukka/run-vcpkg@v7.4
+        with:
+          vcpkgArguments: libarchive
+          vcpkgTriplet: x64-windows-static
+          vcpkgGitCommitId: 0bf3923f9fab4001c00f0f429682a0853b5749e0
+      - name: Check cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+      - uses: actions/upload-artifact@v2
+        with:
+          name: windows
+          path: target/release/starsector_mod_manager.exe

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -649,10 +649,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
  "redox_users",
@@ -2037,6 +2058,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-dialog"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d689b01017db3e350e0e9798d233cca9ad3bf810e7c02b9b55ec06b9ee7dbd8a"
+dependencies = [
+ "cocoa 0.24.0",
+ "dirs-next",
+ "objc",
+ "objc-foundation",
+ "objc_id",
+ "once_cell",
+ "raw-window-handle",
+ "thiserror",
+ "wfd",
+ "which",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "ndk"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3128,6 +3168,7 @@ dependencies = [
  "infer",
  "json5",
  "json_comments",
+ "native-dialog",
  "opener",
  "remove_dir_all 0.7.0",
  "reqwest",
@@ -3689,6 +3730,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wfd"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e713040b67aae5bf1a0ae3e1ebba8cc29ab2b90da9aa1bff6e09031a8a41d7a8"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "wgpu"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3757,6 +3808,17 @@ dependencies = [
  "glyph_brush",
  "log",
  "wgpu",
+]
+
+[[package]]
+name = "which"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea187a8ef279bc014ec368c27a920da2024d2a711109bfbe3440585d5cf27ad9"
+dependencies = [
+ "either",
+ "lazy_static",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3116,7 +3116,7 @@ dependencies = [
 
 [[package]]
 name = "starsector_mod_manager"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "compress-tools",
  "directories",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,12 +19,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9fe5e32de01730eb1f6b7f5b51c17e03e2325bf40a74f754f04f130043affff"
 
 [[package]]
-name = "adler32"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
-
-[[package]]
 name = "ahash"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,27 +196,6 @@ name = "bytes"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
-
-[[package]]
-name = "bzip2"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42b7c3cbf0fa9c1b82308d57191728ca0256cb821220f4e2fd410a72ade26e3b"
-dependencies = [
- "bzip2-sys",
- "libc",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.9+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad3b39a260062fca31f7b0b12f207e8f2590a67d32ec7d59c20484b07ea7285e"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
 
 [[package]]
 name = "calloop"
@@ -495,15 +468,6 @@ dependencies = [
  "core-graphics 0.19.2",
  "libc",
  "objc",
-]
-
-[[package]]
-name = "crc32fast"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
-dependencies = [
- "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -799,18 +763,6 @@ name = "fixedbitset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
-
-[[package]]
-name = "flate2"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cfff41391129e0a856d6d822600b8d71179d46879e310417eb9c762eb178b42"
-dependencies = [
- "cfg-if 0.1.10",
- "crc32fast",
- "libc",
- "miniz_oxide",
-]
 
 [[package]]
 name = "float-ord"
@@ -1966,15 +1918,6 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
-dependencies = [
- "adler32",
-]
 
 [[package]]
 name = "mio"
@@ -3180,7 +3123,6 @@ dependencies = [
  "tinyfiledialogs",
  "tokio",
  "unrar",
- "zip",
 ]
 
 [[package]]
@@ -3995,17 +3937,3 @@ name = "xml-rs"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a"
-
-[[package]]
-name = "zip"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2896475a242c41366941faa27264df2cb935185a92e059a004d0048feb2ac5"
-dependencies = [
- "byteorder",
- "bzip2",
- "crc32fast",
- "flate2",
- "thiserror",
- "time",
-]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3099,7 +3099,7 @@ dependencies = [
 
 [[package]]
 name = "starsector_mod_manager"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "compress-tools",
  "directories",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starsector_mod_manager"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["ikl"]
 edition = "2018"
 description = "A mod manager for the game Starsector"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,15 +23,12 @@ if_chain = "1.0.1"
 reqwest = { version = "0.11.3", default-features = false, features = ["rustls-tls", "json"]}
 serde-aux = "2.1.1"
 handwritten-json = { git = "https://github.com/atlanticaccent/rust-handwritten-json.git" }
-zip = "0.5.9"
 unrar = "0.4.4"
 opener = "0.5"
 directories = "3.0"
 tempfile = "^3.2"
-# libarchive = { git = "https://github.com/AtlanticAccent/libarchive-rust" }
 compress-tools = { git = "https://github.com/OSSystems/compress-tools-rs.git" }
 snafu = "^0.6.10"
-# find_mountpoint = { git = "https://github.com/othiym23/find_mountpoint" } // doesn't quite work
 remove_dir_all = "^0.7.0"
 
 [package.metadata.bundle]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ tokio = { version = "1.6.0", features = ["fs", "io-util", "rt"] }
 iced = { version = "0.3.0", features = ["glow", "tokio"] }
 iced_native ="0.4"
 tinyfiledialogs = "^3.8.3"
+native-dialog = "0.5.5"
 iced_futures = "0.3"
 serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starsector_mod_manager"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["ikl"]
 edition = "2018"
 description = "A mod manager for the game Starsector"

--- a/src/gui/dialogs/dialog.rs
+++ b/src/gui/dialogs/dialog.rs
@@ -1,0 +1,15 @@
+use std::path::PathBuf;
+
+pub trait DialogInterface {
+  fn error(message: String);
+
+  fn notif(message: String);
+
+  fn query(message: String) -> bool;
+
+  fn select_folder(title: &str, path: &str) -> Option<PathBuf>;
+
+  fn select_file_dialog_multiple(title: &str, path: &str, filter: &[&str], filter_label: &str) -> Option<Vec<PathBuf>>;
+}
+
+pub struct Dialog {}

--- a/src/gui/dialogs/macos.rs
+++ b/src/gui/dialogs/macos.rs
@@ -1,0 +1,37 @@
+use std::path::PathBuf;
+
+use tinyfiledialogs as tfd;
+
+mod dialog;
+pub use self::dialog::*;
+
+impl DialogInterface for Dialog {
+  fn error(message: std::string::String) {
+    tfd::message_box_ok("Error", &sanitise(message), tfd::MessageBoxIcon::Error);
+  }
+
+  fn notif(message: std::string::String) {
+    tfd::message_box_ok("Message:", &sanitise(message), tfd::MessageBoxIcon::Info);
+  }
+
+  fn query(message: std::string::String) -> bool {
+    match tfd::message_box_yes_no("Query:", &sanitise(message), tfd::MessageBoxIcon::Question, tfd::YesNo::No) {
+      tfd::YesNo::Yes => true,
+      tfd::YesNo::No => false
+    }
+  }
+  
+  fn select_folder(title: &str, path: &str) -> Option<PathBuf> {
+    tfd::select_folder_dialog(title, path)
+      .map(|p| PathBuf::from(p))
+  }
+
+  fn select_file_dialog_multiple(title: &str, path: &str, filters: &[&str], description: &str) -> Option<Vec<PathBuf>> {
+    tfd::open_file_dialog_multi(title, path, Some((filters, description)))
+      .map(|paths| paths.into_iter().map(|path| PathBuf::from(path)).collect())
+  }
+}
+
+fn sanitise(message: String) -> String {
+  message.replace("'", "`").replace("\"", "`")
+}

--- a/src/gui/dialogs/other.rs
+++ b/src/gui/dialogs/other.rs
@@ -1,0 +1,93 @@
+use std::path::PathBuf;
+
+use native_dialog::{MessageDialog, MessageType, FileDialog};
+
+mod dialog;
+pub use self::dialog::*;
+
+impl DialogInterface for Dialog {
+  fn error(message: String) {
+    let mbox = move || {
+      MessageDialog::new()
+        .set_title("Alert:")
+        .set_type(MessageType::Error)
+        .set_text(&message)
+        .show_alert()
+        .map_err(|err| { err.to_string() })
+    };
+  
+    // On windows we need to spawn a thread as the msg doesn't work otherwise
+    #[cfg(target_os = "windows")]
+    match std::thread::spawn(move || {
+      mbox()
+    }).join() {
+      Ok(Ok(())) => Ok(()),
+      Ok(Err(err)) => Err(err),
+      Err(err) => Err(err).map_err(|err| format!("{:?}", err))
+    }.unwrap();
+    // unwrap() because if this goes to hell there's not really much we can do about it...
+  
+    #[cfg(not(target_os = "windows"))]
+    mbox();
+  }
+
+  fn notif(message: String) {
+    let mbox = move || {
+      MessageDialog::new()
+        .set_title("Alert:")
+        .set_type(MessageType::Info)
+        .set_text(&message)
+        .show_alert()
+        .map_err(|err| { err.to_string() })
+    };
+  
+    // On windows we need to spawn a thread as the msg doesn't work otherwise
+    #[cfg(target_os = "windows")]
+    match std::thread::spawn(move || {
+      mbox()
+    }).join() {
+      Ok(Ok(())) => Ok(()),
+      Ok(Err(err)) => Err(err),
+      Err(err) => Err(err).map_err(|err| format!("{:?}", err))
+    }.unwrap();
+    // unwrap() because if this goes to hell there's not really much we can do about it...
+  
+    #[cfg(not(target_os = "windows"))]
+    mbox();
+  }
+
+  fn query(message: String) -> bool {
+    let mbox = move || {
+      MessageDialog::new()
+      .set_type(MessageType::Warning)
+      .set_text(&message)
+      .show_confirm()
+      .unwrap_or_default()
+    };
+  
+    // On windows we need to spawn a thread as the msg doesn't work otherwise
+    #[cfg(target_os = "windows")]
+    let res = std::thread::spawn(move || {
+      mbox()
+    }).join().unwrap_or_default();
+  
+    #[cfg(not(target_os = "windows"))]
+    let res = mbox();
+  
+    res
+  }
+
+  fn select_folder(_: &str, path: &str) -> Option<PathBuf> {
+    FileDialog::new().set_location(path)
+      .show_open_single_dir()
+      .ok()
+      .flatten()
+  }
+
+  fn select_file_dialog_multiple(_: &str, path: &str, filters: &[&str], description: &str) -> Option<Vec<PathBuf>> {
+    FileDialog::new().set_location(path)
+      .add_filter(description, filters)
+      .show_open_multiple_file()
+      .ok()
+  }
+}

--- a/src/gui/installer.rs
+++ b/src/gui/installer.rs
@@ -18,6 +18,7 @@ use snafu::{Snafu, ResultExt, OptionExt};
 use remove_dir_all::remove_dir_all;
 use infer;
 use unrar;
+use if_chain::if_chain;
 
 use super::mod_list::ModEntry;
 
@@ -198,29 +199,32 @@ async fn handle_path(tx: mpsc::UnboundedSender<ChannelMessage>, path: PathBuf, m
   };
 
   let dir = mod_folder.get_path_copy();
-  if let Ok(maybe_path) = task::spawn_blocking(move || find_nested_mod(&dir)).await.expect("Find mod in given folder") {
-    if let Some(mod_path) = maybe_path {
-      if let Ok(mod_info) = ModEntry::from_file(mod_path.join("mod_info.json")) {
-        if let Some(id) = installed.into_iter().find(|existing| **existing == mod_info.id) {
-          mod_folder = match mod_folder {
-            HybridPath::PathBuf(_) => HybridPath::PathBuf(mod_path.clone()),
-            HybridPath::Temp(temp, _) => HybridPath::Temp(temp, Some(mod_path.clone()))
-          };
+  if_chain! {
+    if let Ok(maybe_path) = task::spawn_blocking(move || find_nested_mod(&dir)).await.expect("Find mod in given folder");
+    if let Some(mod_path) = maybe_path;
+    if let Ok(mod_info) = ModEntry::from_file(mod_path.join("mod_info.json"));
+    then {
+      if let Some(id) = installed.into_iter().find(|existing| **existing == mod_info.id) {
+        mod_folder = match mod_folder {
+          HybridPath::PathBuf(_) => HybridPath::PathBuf(mod_path.clone()),
+          HybridPath::Temp(temp, _) => HybridPath::Temp(temp, Some(mod_path.clone()))
+        };
 
-          tx.send(ChannelMessage::Duplicate(mod_info.name, id, mod_folder, None)).expect("Send query over async channel");
-        } else if !mods_dir.join(mod_info.id.clone()).exists() {
-          move_or_copy(mod_path, mods_dir.join(mod_info.id)).await;
+        tx.send(ChannelMessage::Duplicate(mod_info.name, id, mod_folder, None)).expect("Send query over async channel");
+      } else if !mods_dir.join(mod_info.id.clone()).exists() {
+        move_or_copy(mod_path, mods_dir.join(mod_info.id)).await;
 
-          tx.send(ChannelMessage::Success(mod_info.name)).expect("Send success over async channel");
-        } else {
-          mod_folder = match mod_folder {
-            HybridPath::PathBuf(_) => HybridPath::PathBuf(mod_path.clone()),
-            HybridPath::Temp(temp, _) => HybridPath::Temp(temp, Some(mod_path.clone()))
-          };
+        tx.send(ChannelMessage::Success(mod_info.name)).expect("Send success over async channel");
+      } else {
+        mod_folder = match mod_folder {
+          HybridPath::PathBuf(_) => HybridPath::PathBuf(mod_path.clone()),
+          HybridPath::Temp(temp, _) => HybridPath::Temp(temp, Some(mod_path.clone()))
+        };
 
-          tx.send(ChannelMessage::Duplicate(mod_info.name, String::new(), mod_folder, Some(mods_dir.join(mod_info.id.clone())))).expect("Send query over async channel");
-        }
+        tx.send(ChannelMessage::Duplicate(mod_info.name, String::new(), mod_folder, Some(mods_dir.join(mod_info.id.clone())))).expect("Send query over async channel");
       }
+    } else {
+      tx.send(ChannelMessage::Error(format!("Could not find mod folder or parse mod_info file."))).expect("Send error over async channel");
     }
   }
 }

--- a/src/gui/mod_list.rs
+++ b/src/gui/mod_list.rs
@@ -161,12 +161,7 @@ impl ModList {
           }.to_str().expect("Convert path to string");
 
           match opt {
-            InstallOptions::FromArchive => {
-              let mut filters = vec!["zip", "rar"];
-              if cfg!(unix) {
-                filters.push("7z");
-              }
-
+            InstallOptions::FromSingleArchive | InstallOptions::FromMultipleArchive => {
               if let Some(paths) = tfd::open_file_dialog_multi("Select archives:", start_path, Some((&["*.tar", "*.zip", "*.7z", "*.rar"], "Archive types"))) {
                 if let Some(last) = paths.last() {
                   self.last_browsed = PathBuf::from(last).parent().map(|p| p.to_path_buf());
@@ -701,14 +696,16 @@ impl ModList {
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum InstallOptions {
-  FromArchive,
+  FromMultipleArchive,
+  FromSingleArchive,
   FromFolder,
   Default
 }
 
 impl InstallOptions {
-  const SHOW: [InstallOptions; 2] = [
-    InstallOptions::FromArchive,
+  const SHOW: [InstallOptions; 3] = [
+    InstallOptions::FromMultipleArchive,
+    InstallOptions::FromSingleArchive,
     InstallOptions::FromFolder
   ];
 }
@@ -720,7 +717,8 @@ impl std::fmt::Display for InstallOptions {
       "{}",
       match self {
         InstallOptions::Default => "Install Mod",
-        InstallOptions::FromArchive => "From Archive",
+        InstallOptions::FromMultipleArchive => "From Multiple Archives",
+        InstallOptions::FromSingleArchive => "From Single Archive",
         InstallOptions::FromFolder => "From Folder"
       }
     )

--- a/src/gui/mod_list.rs
+++ b/src/gui/mod_list.rs
@@ -14,7 +14,6 @@ use json_comments::strip_comments;
 use json5;
 use handwritten_json;
 use if_chain::if_chain;
-use tinyfiledialogs as tfd;
 use opener;
 
 use serde_aux::prelude::*;
@@ -162,7 +161,7 @@ impl ModList {
 
           match opt {
             InstallOptions::FromSingleArchive | InstallOptions::FromMultipleArchive => {
-              if let Some(paths) = tfd::open_file_dialog_multi("Select archives:", start_path, Some((&["*.tar", "*.zip", "*.7z", "*.rar"], "Archive types"))) {
+              if let Some(paths) = util::select_file_dialog_multiple("Select archives:", start_path, &["*.tar", "*.zip", "*.7z", "*.rar"], "Archive types") {
                 if let Some(last) = paths.last() {
                   self.last_browsed = PathBuf::from(last).parent().map(|p| p.to_path_buf());
                 }
@@ -181,7 +180,7 @@ impl ModList {
               Command::none()
             },
             InstallOptions::FromFolder => {
-              match tfd::select_folder_dialog("Select mod folder:", start_path) {
+              match util::select_folder_dialog("Select mod folder:", start_path) {
                 Some(source_path) => {
                   self.last_browsed = PathBuf::from(&source_path).parent().map(|p| p.to_path_buf());
                   

--- a/src/gui/settings.rs
+++ b/src/gui/settings.rs
@@ -87,7 +87,7 @@ impl Settings {
       },
       SettingsMessage::OpenNativeFilePick => {
         let maybe_path = if cfg!(target_os = "macos") {
-          tfd::open_file_dialog("Select Starsector app:", UserDirs::new().unwrap().document_dir().unwrap().to_str().unwrap(), Some((vec!["*.app"], "*.app")), false)
+          tfd::open_file_dialog("Select Starsector app:", UserDirs::new().unwrap().document_dir().unwrap().to_str().unwrap(), Some((&["*.app"], "*.app")))
         } else {
           tfd::select_folder_dialog("Select Starsector installation:", UserDirs::new().unwrap().document_dir().unwrap().to_str().unwrap())
         };

--- a/src/gui/util.rs
+++ b/src/gui/util.rs
@@ -1,27 +1,32 @@
-use tinyfiledialogs as tfd;
 use if_chain::if_chain;
 use json_comments::strip_comments;
-use std::io::Read;
+use std::{io::Read, path::PathBuf};
+
+#[cfg_attr(target_os = "macos", path = "dialogs/macos.rs")]
+#[cfg_attr(not(target_os = "macos"), path = "dialogs/other.rs")]
+mod dialogs;
+pub use self::dialogs::*;
 
 use crate::gui::mod_list::ModVersionMeta;
 
 pub fn error<T: AsRef<str>>(message: T) {
-  tfd::message_box_ok("Error", sanitise(message).as_ref(), tfd::MessageBoxIcon::Error);
+  Dialog::error(String::from(message.as_ref()));
 }
 
 pub fn notif<T: AsRef<str>>(message: T) {
-  tfd::message_box_ok("Message:", sanitise(message).as_ref(), tfd::MessageBoxIcon::Info);
+  Dialog::notif(String::from(message.as_ref()));
 }
 
 pub fn query<T: AsRef<str>>(message: T) -> bool {
-  match tfd::message_box_yes_no("Query:", sanitise(message).as_ref(), tfd::MessageBoxIcon::Question, tfd::YesNo::No) {
-    tfd::YesNo::Yes => true,
-    tfd::YesNo::No => false
-  }
+  Dialog::query(String::from(message.as_ref()))
 }
 
-fn sanitise<T: AsRef<str>>(message: T) -> String {
-  message.as_ref().replace("'", "`").replace("\"", "`")
+pub fn select_folder_dialog(title: &str, path: &str) -> Option<PathBuf> {
+  Dialog::select_folder(title, path)
+}
+
+pub fn select_file_dialog_multiple(title: &str, path: &str, filter: &[&str], filter_label: &str) -> Option<Vec<PathBuf>> {
+  Dialog::select_file_dialog_multiple(title, path, filter, filter_label)
 }
 
 pub async fn get_master_version(local: ModVersionMeta) -> (String, Result<Option<ModVersionMeta>, String>) {


### PR DESCRIPTION
- Add quotation sanitisation to messages using tfd so that errors don't cause an error when being printed
- Fix macOS installation selector incorrectly using a save dialog instead of a select dialog. Make it so it can only select .app "files"
- Patch rar support using unrar
- Add script that may make macOS binaries truly portable (fixes brew libarchive crash)
- Make install from multiple an explicit option (both install from archive buttons allow for selecting multiple archives though)
- Add messaging indicating malformed mod_info caused an install failure