### PR TITLE
Allow app to run on older macOS major versions

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -24,8 +24,6 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - name: Install cargo-bundle
-        run: cargo install cargo-bundle
       - name: Check cache
         uses: actions/cache@v2
         with:
@@ -36,6 +34,10 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install cargo-bundle
+        run: (cargo install cargo-bundle || true)
+      - name: Emit target macOS version env variable
+        run: echo MACOSX_DEPLOYMENT_TARGET=10.10 >> $GITHUB_ENV
       - name: Run cargo-bundle
         run: cargo bundle --release
       - name: Run make_portable.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,4 @@ sublime_fuzzy = "0.7.0"
 [package.metadata.bundle]
 name = "Starsector Mod Manager"
 id = "org.laird.starsector_mod_manager"
+osx_minimum_system_version = "10.10"


### PR DESCRIPTION
macOS 10.15(?) disabled running 32 bit applications, because Apple, meaning some users have intentionally not updated beyond 10.14. Other users may not have updated out of some other preference, or simply because their machines are unsupported on later versions.

Utilising cargo-bundle properties and the MACOS_DEPLOYMENT_TARGET env var, we can target a specific macOS version instead of the default. The env var is more important, as it influences not only the main binary but how dependencies are compiled - and some dependencies using C/C++ libs will only compile on certain macOS versions and beyond due to library dependencies of their own.

Currently, the lowest tested and successful version is 10.10. The lowest possible, 10.7, causes unrar to fail to build to some C++ lib not being present in the standard lib.