### PR TITLE
Detect currently installed/selected Starsector version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9fe5e32de01730eb1f6b7f5b51c17e03e2325bf40a74f754f04f130043affff"
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "ahash"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -26,9 +32,9 @@ checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
@@ -198,6 +204,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
+name = "bzip2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6afcd980b5f3a45017c57e57a2fcccbb351cc43a356ce117ef760ef8052b89b0"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "calloop"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,6 +242,12 @@ checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
 dependencies = [
  "jobserver",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -254,6 +287,17 @@ dependencies = [
  "num-traits 0.2.14",
  "time",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "classfile-parser"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f0f4b8dd92b7b55a82f76e0559370f24a52dd082ded228993ab582cf1fe118"
+dependencies = [
+ "bitflags",
+ "cesu8",
+ "nom 4.2.3",
 ]
 
 [[package]]
@@ -468,6 +512,15 @@ dependencies = [
  "core-graphics 0.19.2",
  "libc",
  "objc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "738c290dfaea84fc1ca15ad9c168d083b05a714e1efddd8edaab678dc28d2836"
+dependencies = [
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -763,6 +816,18 @@ name = "fixedbitset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
+
+[[package]]
+name = "flate2"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crc32fast",
+ "libc",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "float-ord"
@@ -1179,7 +1244,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "579160312273c954cc51bd440f059dde741029ac8daf8c84fece76cb77f62c15"
 dependencies = [
- "version_check",
+ "version_check 0.9.2",
 ]
 
 [[package]]
@@ -1891,9 +1956,9 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memmap2"
@@ -1932,6 +1997,16 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+dependencies = [
+ "adler",
+ "autocfg",
+]
 
 [[package]]
 name = "mio"
@@ -2115,12 +2190,22 @@ dependencies = [
 
 [[package]]
 name = "nom"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
+dependencies = [
+ "memchr",
+ "version_check 0.1.5",
+]
+
+[[package]]
+name = "nom"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab6f70b46d6325aa300f1c7bb3d470127dfc27806d8ea6bf294ee0ce643ce2b1"
 dependencies = [
  "memchr",
- "version_check",
+ "version_check 0.9.2",
 ]
 
 [[package]]
@@ -2719,9 +2804,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.6"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a26af418b574bd56588335b3a3659a65725d4e636eb1016c2f9e3b38c7cc759"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3115,6 +3200,7 @@ dependencies = [
 name = "starsector_mod_manager"
 version = "0.4.4"
 dependencies = [
+ "classfile-parser",
  "compress-tools",
  "directories",
  "handwritten-json",
@@ -3126,8 +3212,10 @@ dependencies = [
  "infer",
  "json5",
  "json_comments",
+ "lazy_static",
  "native-dialog",
  "opener",
+ "regex",
  "remove_dir_all 0.7.0",
  "reqwest",
  "serde",
@@ -3139,6 +3227,7 @@ dependencies = [
  "tinyfiledialogs",
  "tokio",
  "unrar",
+ "zip",
 ]
 
 [[package]]
@@ -3473,6 +3562,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "version_check"
@@ -3939,7 +4034,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a9a231574ae78801646617cefd13bfe94be907c0e4fa979cfd8b770aa3c5d08"
 dependencies = [
- "nom",
+ "nom 6.1.0",
 ]
 
 [[package]]
@@ -3959,3 +4054,17 @@ name = "xml-rs"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a"
+
+[[package]]
+name = "zip"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93ab48844d61251bb3835145c521d88aa4031d7139e8485990f60ca911fa0815"
+dependencies = [
+ "byteorder",
+ "bzip2",
+ "crc32fast",
+ "flate2",
+ "thiserror",
+ "time",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ description = "A mod manager for the game Starsector"
 infer = "0.3.4"
 tokio = { version = "1.6.0", features = ["fs", "io-util", "rt"] }
 iced = { version = "0.3.0", features = ["glow", "tokio"] }
-iced_native ="0.4"
+iced_native = "0.4"
 iced_aw = { git = "https://github.com/iced-rs/iced_aw", branch = "main", default-features = false, features = ["modal", "card"] }
 tinyfiledialogs = "^3.8.3"
 native-dialog = "0.5.5"
@@ -32,6 +32,10 @@ compress-tools = { git = "https://github.com/OSSystems/compress-tools-rs.git" }
 snafu = "^0.6.10"
 remove_dir_all = "^0.7.0"
 sublime_fuzzy = "0.7.0"
+classfile-parser = "~0.3"
+zip = "^0.5"
+regex = "1.5"
+lazy_static = "1.4"
 
 [package.metadata.bundle]
 name = "Starsector Mod Manager"

--- a/src/gui/settings.rs
+++ b/src/gui/settings.rs
@@ -20,7 +20,9 @@ pub struct Settings {
   min_ram_input_state: text_input::State,
   max_ram_input_state: text_input::State,
   min_ram_pick_state: pick_list::State<vmparams::Unit>,
-  max_ram_pick_state: pick_list::State<vmparams::Unit>
+  max_ram_pick_state: pick_list::State<vmparams::Unit>,
+  manager_update_url: bool,
+  manager_update_button_state: button::State
 }
 
 #[derive(Debug, Clone)]
@@ -33,7 +35,9 @@ pub enum SettingsMessage {
   InitVMParams(Option<vmparams::VMParams>),
   VMParamsEditingToggled(bool),
   VMParamChanged(String, VMParamChanged),
-  UnitChanged(vmparams::Unit, VMParamChanged)
+  UnitChanged(vmparams::Unit, VMParamChanged),
+  InitUpdateStatus(bool),
+  OpenReleases
 }
 
 #[derive(Debug, Clone)]
@@ -57,12 +61,22 @@ impl Settings {
       min_ram_input_state: text_input::State::new(),
       max_ram_input_state: text_input::State::new(),
       min_ram_pick_state: pick_list::State::default(),
-      max_ram_pick_state: pick_list::State::default()
+      max_ram_pick_state: pick_list::State::default(),
+      manager_update_url: false,
+      manager_update_button_state: button::State::new(),
     }
   }
 
   pub fn update(&mut self, message: SettingsMessage) -> Command<SettingsMessage> {
     match message {
+      SettingsMessage::InitUpdateStatus(status) => {
+        self.manager_update_url = status;
+
+        Command::none()
+      },
+      SettingsMessage::OpenReleases => {
+        Command::none()
+      },
       SettingsMessage::InitRoot(mut _root_dir) => {
         self.root_dir = _root_dir.take();
         self.dirty = false;
@@ -181,7 +195,7 @@ impl Settings {
     )
     .on_press(SettingsMessage::OpenNativeFilePick);
   
-    let mut controls = vec![
+    let mut controls: Vec<Element<SettingsMessage>> = vec![
       Row::new()
         .push({
           if cfg!(target_os = "macos") {
@@ -273,6 +287,21 @@ impl Settings {
         .center_y()
         .height(Length::FillPortion(1))
       )
+      .push(if self.manager_update_url {
+        Row::new()
+          .push(Space::with_width(Length::Fill))
+          .push(Text::new("Mod Manager update available:"))
+          .push(Space::with_width(Length::Units(10)))
+          .push(Button::new(
+            &mut self.manager_update_button_state,
+            Text::new("Open in browser?")
+            ).on_press(SettingsMessage::OpenReleases)
+          )
+          .align_items(iced::Align::Center)
+      } else {
+        Row::new().height(Length::Shrink)
+      })
+      .push(Space::with_height(Length::Units(10)))
       .push::<Element<SettingsMessage>>(
         Row::new()
           .push(Space::with_width(Length::Fill))
@@ -303,5 +332,5 @@ THE SOFTWARE IS PROVIDED `AS IS`, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 This program makes use of multiple open source components and framewords. They include, and are not limited to:
 
-iced, serde, tokio, infer, native-dialog, serde_json, json5, json_comments, and if_chain.
+infer, tokio, iced, iced_native, iced_aw, tinyfiledialogs, native-dialog, iced_futures, serde, serde_json, json5, json_comments, if_chain, reqwest, serde-aux, handwritten-json, unrar, opener, directories, tempfile, compress-tools, snafu, remove_dir_all, sublime_fuzzy, classfile-parser, zip, regex, lazy_static
 "#;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 #![recursion_limit="1000"]
 #![feature(option_zip)]
+#![feature(result_flattening)]
+#![feature(async_closure)]
 
 use iced::{Application, Settings};
 


### PR DESCRIPTION
Also modifies manager version to be displayed in window title.
Detected starsector version is displayed in pseudo-title bar.
Manager updates generate a popup on app start if they are detected, and
will always be accessible from the settings page if detected.
I have changed _way_ too much at once in this commit.
Fixes #104