### PR TITLE
Linux static compile fix

### DIFF
--- a/.github/workflows/linux_static.yml
+++ b/.github/workflows/linux_static.yml
@@ -13,12 +13,12 @@ jobs:
   build:
     name: Rust project
     runs-on: ubuntu-latest
-    container: alpine:3.14
+    container: rust:alpine
     env:
       PKG_CONFIG_ALLOW_CROSS: 1
     steps:
       - name: Install Dependencies
-        run: apk update; apk add libarchive-dev musl
+        run: apk update; apk add libarchive-dev git
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/linux_static.yml
+++ b/.github/workflows/linux_static.yml
@@ -18,7 +18,7 @@ jobs:
       PKG_CONFIG_ALLOW_CROSS: 1
     steps:
       - name: Install Dependencies
-        run: apk update; apk add libarchive-dev musl-dev gcc g++ libgcc make cmake binutils freetype-dev
+        run: apk update; apk add libarchive-dev musl-dev gcc g++ libgcc make cmake binutils freetype-dev expat-dev
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/linux_static.yml
+++ b/.github/workflows/linux_static.yml
@@ -18,7 +18,7 @@ jobs:
       PKG_CONFIG_ALLOW_CROSS: 1
     steps:
       - name: Install Dependencies
-        run: apk update; apk add libarchive-dev musl-dev gcc g++ libgcc make cmake binutils freetype2
+        run: apk update; apk add libarchive-dev musl-dev gcc g++ libgcc make cmake binutils freetype-dev
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/linux_static.yml
+++ b/.github/workflows/linux_static.yml
@@ -18,7 +18,7 @@ jobs:
       PKG_CONFIG_ALLOW_CROSS: 1
     steps:
       - name: Install Dependencies
-        run: apk update; apk add libarchive-dev musl-dev g++ libgcc cmake
+        run: apk update; apk add libarchive-dev musl-dev gcc g++ libgcc make cmake binutils
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/linux_static.yml
+++ b/.github/workflows/linux_static.yml
@@ -18,7 +18,7 @@ jobs:
       PKG_CONFIG_ALLOW_CROSS: 1
     steps:
       - name: Install Dependencies
-        run: apk update; apk add libarchive-dev git
+        run: apk update; apk add libarchive-dev git musl-dev
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/linux_static.yml
+++ b/.github/workflows/linux_static.yml
@@ -18,7 +18,7 @@ jobs:
       PKG_CONFIG_ALLOW_CROSS: 1
     steps:
       - name: Install Dependencies
-        run: apk update; apk install libarchive-dev musl
+        run: apk update; apk add libarchive-dev musl
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/linux_static.yml
+++ b/.github/workflows/linux_static.yml
@@ -13,13 +13,12 @@ jobs:
   build:
     name: Rust project
     runs-on: ubuntu-latest
+    container: alpine:3.14
     env:
       PKG_CONFIG_ALLOW_CROSS: 1
     steps:
       - name: Install Dependencies
-        run: sudo apt-get update; sudo apt-get install libarchive-dev musl-tools
-      - name: Link g++ to musl-g++
-        run: sudo ln -s /bin/g++ /bin/musl-g++
+        run: sudo apk update; sudo apk install libarchive-dev musl
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/linux_static.yml
+++ b/.github/workflows/linux_static.yml
@@ -18,7 +18,7 @@ jobs:
       PKG_CONFIG_ALLOW_CROSS: 1
     steps:
       - name: Install Dependencies
-        run: apk update; apk add libarchive-dev git musl-dev g++ libgcc cmake
+        run: apk update; apk add libarchive-dev musl-dev g++ libgcc cmake
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/linux_static.yml
+++ b/.github/workflows/linux_static.yml
@@ -18,7 +18,7 @@ jobs:
       PKG_CONFIG_ALLOW_CROSS: 1
     steps:
       - name: Install Dependencies
-        run: apk update; apk add libarchive-dev musl-dev gcc g++ libgcc make cmake binutils
+        run: apk update; apk add libarchive-dev musl-dev gcc g++ libgcc make cmake binutils freetype2
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/linux_static.yml
+++ b/.github/workflows/linux_static.yml
@@ -18,7 +18,7 @@ jobs:
       PKG_CONFIG_ALLOW_CROSS: 1
     steps:
       - name: Install Dependencies
-        run: apk update; apk add libarchive-dev git musl-dev g++ libgcc
+        run: apk update; apk add libarchive-dev git musl-dev g++ libgcc cmake
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/linux_static.yml
+++ b/.github/workflows/linux_static.yml
@@ -18,7 +18,7 @@ jobs:
       PKG_CONFIG_ALLOW_CROSS: 1
     steps:
       - name: Install Dependencies
-        run: apk update; apk add libarchive-dev git musl-dev
+        run: apk update; apk add libarchive-dev git musl-dev g++ libgcc
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/linux_static.yml
+++ b/.github/workflows/linux_static.yml
@@ -18,7 +18,7 @@ jobs:
       PKG_CONFIG_ALLOW_CROSS: 1
     steps:
       - name: Install Dependencies
-        run: sudo apk update; sudo apk install libarchive-dev musl
+        run: apk update; apk install libarchive-dev musl
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = "1.0"
 json5 = "0.3.0"
 json_comments = "0.1.0"
 if_chain = "1.0.1"
-reqwest = { version = "0.11.3", default-features = false, features = ["rustls-tls", "json"]}
+reqwest = { version = "0.11.7", default-features = false, features = ["rustls-tls", "json"]}
 serde-aux = "2.1.1"
 handwritten-json = { git = "https://github.com/atlanticaccent/rust-handwritten-json.git" }
 unrar = "0.4.4"


### PR DESCRIPTION
Fix static Linux compiles using musl.

Switch to running entirely on official Rust-Alpine Docker container.
Install basically every dep manually.
Otherwise compile as normal.