### PR TITLE
Move overwrite queries to single window

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,19 +1,20 @@
-use std::{path::PathBuf, process, sync::Arc};
+use std::{path::PathBuf, process, rc::Rc, sync::Arc};
 
 use chrono::Local;
 use druid::{
   commands,
+  im::Vector,
   keyboard_types::Key,
   lens, theme,
   widget::{
-    Axis, Button, Checkbox, Controller, Flex, Label, Maybe, Painter, Scope, ScopeTransfer, Scroll,
+    Axis, Button, Checkbox, Controller, Flex, Label, Maybe, Painter, Scope, ScopeTransfer,
     SizedBox, Tabs, TabsPolicy, TextBox, ViewSwitcher,
   },
   AppDelegate as Delegate, Command, Data, DelegateCtx, Env, Event, EventCtx, Handled, KeyEvent,
   Lens, LensExt, Menu, MenuItem, RenderContext, Selector, Target, Widget, WidgetExt, WidgetId,
   WindowDesc, WindowId,
 };
-use druid_widget_nursery::{material_icons::Icon, WidgetExt as WidgetExtNursery};
+use druid_widget_nursery::{material_icons::Icon, Separator, WidgetExt as WidgetExtNursery};
 use lazy_static::lazy_static;
 use rfd::FileDialog;
 use self_update::version::bump_is_greater;
@@ -27,7 +28,7 @@ use crate::patch::{
 };
 
 use self::{
-  installer::{ChannelMessage, StringOrPath},
+  installer::{ChannelMessage, HybridPath, StringOrPath},
   mod_description::ModDescription,
   mod_entry::{ModEntry, UpdateStatus},
   mod_list::{EnabledMods, Filters, ModList},
@@ -64,6 +65,7 @@ pub struct App {
   widget_id: WidgetId,
   #[data(same_fn = "PartialEq::eq")]
   log: Vec<String>,
+  overwrite_log: Vector<Rc<(StringOrPath, HybridPath, Arc<ModEntry>)>>,
 }
 
 impl App {
@@ -81,6 +83,11 @@ impl App {
   const CLEAR_LOG: Selector = Selector::new("app.install.clear_log");
   const LOG_ERROR: Selector<(String, String)> = Selector::new("app.mod.install.fail");
   const LOG_MESSAGE: Selector<String> = Selector::new("app.mod.install.start");
+  const LOG_OVERWRITE: Selector<(StringOrPath, HybridPath, Arc<ModEntry>)> =
+    Selector::new("app.mod.install.overwrite");
+  const CLEAR_OVERWRITE_LOG: Selector<bool> = Selector::new("app.install.clear_overwrite_log");
+  const REMOVE_OVERWRITE_LOG_ENTRY: Selector<StringOrPath> =
+    Selector::new("app.install.overwrite.decline");
 
   pub fn new(handle: Handle) -> Self {
     App {
@@ -103,6 +110,7 @@ impl App {
       runtime: handle,
       widget_id: WidgetId::reserved(0),
       log: Vec::new(),
+      overwrite_log: Vector::new(),
     }
   }
 
@@ -493,6 +501,12 @@ impl App {
       .log
       .push(format!("[{}] {}", Local::now().format("%H:%M:%S"), message))
   }
+
+  fn push_overwrite(&mut self, message: (StringOrPath, HybridPath, Arc<ModEntry>)) {
+    if !self.overwrite_log.iter().any(|val| val.0 == message.0) {
+      self.overwrite_log.push_back(Rc::new(message))
+    }
+  }
 }
 
 enum AppCommands {
@@ -506,6 +520,7 @@ pub struct AppDelegate {
   root_id: Option<WindowId>,
   log_window: Option<WindowId>,
   fail_window: Option<WindowId>,
+  overwrite_window: Option<WindowId>,
 }
 
 impl Delegate<App> for AppDelegate {
@@ -632,16 +647,51 @@ impl Delegate<App> for AppDelegate {
       self.display_log_if_closed(ctx);
 
       return Handled::Yes;
+    } else if let Some(message) = cmd.get(App::LOG_OVERWRITE) {
+      data.push_overwrite(message.clone());
+      self.display_overwrite_if_closed(ctx);
+
+      return Handled::Yes;
+    } else if let Some(ovewrite_all) = cmd.get(App::CLEAR_OVERWRITE_LOG) {
+      if *ovewrite_all {
+        for val in &data.overwrite_log {
+          let (conflict, to_install, entry) = val.as_ref();
+          ctx.submit_command(ModList::OVERWRITE.with((
+            match conflict {
+              StringOrPath::String(id) => data.mod_list.mods.get(id).unwrap().path.clone(),
+              StringOrPath::Path(path) => path.clone(),
+            },
+            to_install.clone(),
+            entry.clone(),
+          )))
+        }
+      }
+      data.overwrite_log.clear();
+
+      return Handled::Yes;
+    } else if let Some(overwrite_entry) = cmd.get(App::REMOVE_OVERWRITE_LOG_ENTRY) {
+      data.overwrite_log.retain(|val| val.0 != *overwrite_entry);
+      if data.overwrite_log.len() == 0 {
+        if let Some(id) = self.overwrite_window.take() {
+          ctx.submit_command(commands::CLOSE_WINDOW.to(id))
+        }
+      }
+
+      return Handled::Yes;
     }
 
     Handled::No
   }
 
-  fn window_removed(&mut self, id: WindowId, _data: &mut App, _env: &Env, ctx: &mut DelegateCtx) {
+  fn window_removed(&mut self, id: WindowId, data: &mut App, _env: &Env, ctx: &mut DelegateCtx) {
     match Some(id) {
       a @ _ if a == self.settings_id => self.settings_id = None,
       a @ _ if a == self.log_window => self.log_window = None,
       a @ _ if a == self.fail_window => self.fail_window = None,
+      a @ _ if a == self.overwrite_window => {
+        data.overwrite_log.clear();
+        self.overwrite_window = None;
+      }
       a @ _ if a == self.root_id => ctx.submit_command(commands::QUIT_APP),
       _ => {}
     }
@@ -682,27 +732,18 @@ impl Delegate<App> for AppDelegate {
 
 impl AppDelegate {
   fn build_log_window() -> impl Widget<App> {
-    Modal::new("Log")
-      .with_content("")
-      .with_content(
-        Scroll::new(ViewSwitcher::new(
-          |data: &App, _| data.log.len(),
-          |_, data: &App, _| {
-            Flex::column()
-              .tap_mut(|flex| {
-                for val in data.log.iter() {
-                  flex.add_child(Label::wrapped(val))
-                }
-              })
-              .cross_axis_alignment(druid::widget::CrossAxisAlignment::Start)
-              .boxed()
-          },
-        ))
-        .vertical()
-        .boxed(),
-      )
-      .with_button("Close", App::CLEAR_LOG)
-      .build()
+    ViewSwitcher::new(
+      |data: &App, _| data.log.len(),
+      |_, data: &App, _| {
+        let mut modal = Modal::new("Log").with_content("");
+
+        for val in data.log.iter() {
+          modal = modal.with_content(val.as_str())
+        }
+
+        modal.with_button("Close", App::CLEAR_LOG).build().boxed()
+      },
+    )
   }
 
   fn display_log_if_closed(&mut self, ctx: &mut DelegateCtx) {
@@ -716,6 +757,120 @@ impl AppDelegate {
       self.log_window = Some(log_window.id);
 
       ctx.new_window(log_window);
+    }
+  }
+
+  fn build_overwrite_window() -> impl Widget<App> {
+    ViewSwitcher::new(
+      |data: &App, _| data.overwrite_log.len(),
+      |_, data: &App, _| {
+        let mut modal = Modal::new("Overwrite?");
+
+        for val in data.overwrite_log.iter() {
+          let (conflict, to_install, entry) = val.as_ref();
+          modal = modal
+            .with_content(match conflict {
+              StringOrPath::String(id) => format!("A mod with ID {} alread exists.", id),
+              StringOrPath::Path(path) => format!(
+                "Found a folder at the path {} when trying to install {}.",
+                path.to_string_lossy(),
+                entry.id
+              ),
+            })
+            .with_content(
+              Maybe::or_empty(|| {
+                Label::wrapped(
+                  "\
+              NOTE: A .git directory has been detected in the target directory. \
+              Are you sure this isn't being used for development?\
+            ",
+                )
+              })
+              .lens(lens::Constant(
+                data
+                  .settings
+                  .git_warn
+                  .then(|| {
+                    if entry.path.join(".git").exists() {
+                      Some(())
+                    } else {
+                      None
+                    }
+                  })
+                  .flatten(),
+              ))
+              .boxed(),
+            )
+            .with_content(format!(
+              "Would you like to replace the existing {}?",
+              if let StringOrPath::String(_) = conflict {
+                "mod"
+              } else {
+                "folder"
+              }
+            ))
+            .with_content(
+              Flex::row()
+                .with_flex_spacer(1.)
+                .with_child(Button::new("Overwrite").on_click({
+                  let conflict = conflict.clone();
+                  let to_install = to_install.clone();
+                  let entry = entry.clone();
+                  move |ctx: &mut EventCtx, data: &mut App, _| {
+                    ctx.submit_command(App::REMOVE_OVERWRITE_LOG_ENTRY.with(conflict.clone()));
+                    ctx.submit_command(ModList::OVERWRITE.with((
+                      match &conflict {
+                        StringOrPath::String(id) => {
+                          data.mod_list.mods.get(id).unwrap().path.clone()
+                        }
+                        StringOrPath::Path(path) => path.clone(),
+                      },
+                      to_install.clone(),
+                      entry.clone(),
+                    )))
+                  }
+                }))
+                .with_child(Button::new("Cancel").on_click({
+                  let conflict = conflict.clone();
+                  move |ctx, _, _| {
+                    ctx.submit_command(App::REMOVE_OVERWRITE_LOG_ENTRY.with(conflict.clone()))
+                  }
+                }))
+                .boxed(),
+            )
+            .with_content(
+              Separator::new()
+                .with_width(2.0)
+                .with_color(druid::Color::GRAY)
+                .padding((0., 0., 0., 10.))
+                .boxed(),
+            );
+        }
+
+        if data.overwrite_log.len() > 1 {
+          modal
+            .with_button("Overwrite All", App::CLEAR_OVERWRITE_LOG.with(true))
+            .with_button("Cancel All", App::CLEAR_OVERWRITE_LOG.with(false))
+        } else {
+          modal.with_button("Close", App::CLEAR_OVERWRITE_LOG.with(false))
+        }
+        .build()
+        .boxed()
+      },
+    )
+  }
+
+  fn display_overwrite_if_closed(&mut self, ctx: &mut DelegateCtx) {
+    if self.overwrite_window.is_none() {
+      let modal = Self::build_overwrite_window();
+
+      let overwrite_window = WindowDesc::new(modal)
+        .window_size((500., 400.))
+        .show_titlebar(false);
+
+      self.overwrite_window = Some(overwrite_window.id);
+
+      ctx.new_window(overwrite_window);
     }
   }
 }
@@ -824,64 +979,9 @@ impl<W: Widget<App>> Controller<App, W> for ModListController {
             ctx.children_changed();
             ctx.submit_command(App::LOG_SUCCESS.with(entry.name.clone()));
           }
-          ChannelMessage::Duplicate(conflict, to_install, entry) => {
-            Modal::new("Overwrite existing?")
-              .with_content(format!(
-                "Encountered conflict when trying to install {}",
-                entry.id
-              ))
-              .with_content(match conflict {
-                StringOrPath::String(id) => format!("A mod with ID {} alread exists.", id),
-                StringOrPath::Path(path) => format!(
-                  "A folder already exists at the path {}.",
-                  path.to_string_lossy()
-                ),
-              })
-              .with_content(
-                Maybe::or_empty(|| {
-                  Label::wrapped(
-                    "\
-                  NOTE: A .git directory has been detected in the target directory. \
-                  Are you sure this isn't being used for development?\
-                ",
-                  )
-                })
-                .lens(lens::Constant(
-                  data
-                    .settings
-                    .git_warn
-                    .then(|| {
-                      if entry.path.join(".git").exists() {
-                        Some(())
-                      } else {
-                        None
-                      }
-                    })
-                    .flatten(),
-                ))
-                .boxed(),
-              )
-              .with_content(format!(
-                "Would you like to replace the existing {}?",
-                if let StringOrPath::String(_) = conflict {
-                  "mod"
-                } else {
-                  "folder"
-                }
-              ))
-              .with_button(
-                "Overwrite",
-                ModList::OVERWRITE.with((
-                  match conflict {
-                    StringOrPath::String(id) => data.mod_list.mods.get(id).unwrap().path.clone(),
-                    StringOrPath::Path(path) => path.clone(),
-                  },
-                  to_install.clone(),
-                  entry.clone(),
-                )),
-              )
-              .show(ctx, env, &());
-          }
+          ChannelMessage::Duplicate(conflict, to_install, entry) => ctx.submit_command(
+            App::LOG_OVERWRITE.with((conflict.clone(), to_install.clone(), entry.clone())),
+          ),
           ChannelMessage::Error(name, err) => {
             ctx.submit_command(App::LOG_ERROR.with((name.clone(), err.clone())));
             eprintln!("Failed to install {}", err);

--- a/src/app/installer.rs
+++ b/src/app/installer.rs
@@ -325,7 +325,7 @@ pub enum ChannelMessage {
   Error(String, String),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum StringOrPath {
   String(String),
   Path(PathBuf),

--- a/src/app/modal.rs
+++ b/src/app/modal.rs
@@ -66,7 +66,7 @@ impl<'a, T: Data> Modal<'a, T> {
           .background(theme::BACKGROUND_LIGHT)
           .controller(DragWindowController::default()),
       )
-      .with_child(
+      .with_flex_child(
         Flex::column()
           .tap_mut(|flex| {
             for content in self.contents.drain(..) {
@@ -78,24 +78,33 @@ impl<'a, T: Data> Modal<'a, T> {
             }
           })
           .cross_axis_alignment(druid::widget::CrossAxisAlignment::Start)
-          .expand_width()
-          .padding(20.),
+          .main_axis_alignment(druid::widget::MainAxisAlignment::Start)
+          .padding(20.)
+          .scroll()
+          .vertical()
+          .expand(),
+          1.
       )
-      .with_flex_spacer(1.)
-      .with_child(Flex::row().with_flex_spacer(1.).tap_mut(|flex| {
-        for (label, commands) in self.buttons {
-          flex.add_child(Button::new(label).on_click({
-            let commands = commands.clone();
-            move |ctx, _, _| {
-              for command in &commands {
-                ctx.submit_command(command.clone().to(Target::Global))
-              }
-              ctx.submit_command(commands::CLOSE_WINDOW)
+      .with_child(
+        Flex::row()
+          .with_flex_spacer(1.)
+          .tap_mut(|flex| {
+            for (label, commands) in self.buttons {
+              flex.add_child(Button::new(label).on_click({
+                let commands = commands.clone();
+                move |ctx, _, _| {
+                  for command in &commands {
+                    ctx.submit_command(command.clone().to(Target::Global))
+                  }
+                  ctx.submit_command(commands::CLOSE_WINDOW)
+                }
+              }))
             }
-          }))
-        }
-      }))
+          }),
+      )
       .cross_axis_alignment(druid::widget::CrossAxisAlignment::Start)
+      .main_axis_alignment(druid::widget::MainAxisAlignment::SpaceBetween)
+      .expand()
   }
 
   pub fn show(self, ctx: &mut (impl AnyCtx + RequestCtx), env: &Env, data: &T) -> WindowId {


### PR DESCRIPTION
Reduces overwhelming number of popups that occur when updating multiple mods.
Also fixes log (and by extension all) modals not scaling with contents - by default now, all modals will scroll their primary contents.