### PR TITLE
fix: do not preserve archive file permissions

### DIFF
--- a/src/app/installer.rs
+++ b/src/app/installer.rs
@@ -163,14 +163,14 @@ pub fn decompress(path: PathBuf) -> Result<TempDir, InstallError> {
       compress_tools::uncompress_archive(
         source,
         temp_dir.path(),
-        compress_tools::Ownership::Preserve,
+        compress_tools::Ownership::Ignore,
       )
       .context(CompressTools {})?
     }
     _ => compress_tools::uncompress_archive(
       source,
       temp_dir.path(),
-      compress_tools::Ownership::Preserve,
+      compress_tools::Ownership::Ignore,
     )
     .context(CompressTools {})?,
   }


### PR DESCRIPTION
Partially fixes https://github.com/atlanticaccent/starsector-mod-manager-rust/issues/158.

Specifically, this fixes the issue when installing from an archive. The error when installing from the web browser is different from the one when trying to install via an archive. I'll add some documentation to the ticket reflecting that.